### PR TITLE
Adapt terminal bg/fg colors to the editor's style

### DIFF
--- a/plugins/terminal/init.lua
+++ b/plugins/terminal/init.lua
@@ -45,9 +45,9 @@ config.plugins.terminal = common.merge({
   -- padding around the edges of the terminal
   padding = { x = 0, y = 0 },
   -- default background color if not explicitly set by the shell
-  background = { common.color "#000000" },
+  background = style.background,
   -- default text color if not explicitly by the shell
-  text = { common.color "#FFFFFF" },
+  text = style.syntax.normal,
   -- show bold text in bright colors
   bold_text_in_bright_colors = true,
   colors = {


### PR DESCRIPTION
Without changing the terminal colors adjust the visual appearence of the terminal to blend with the editor's style.